### PR TITLE
Remove tox `isolated_build` config options

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist =
     py{3.12, 3.11, 3.10, 3.9, 3.8}{-brotli, }{-zopfli, }
     coverage_report
 skip_missing_interpreters = True
-isolated_build = True
 labels =
     update=update
 


### PR DESCRIPTION

Tox 4 made this the default, and the option has been removed ([reference](https://tox.wiki/en/latest/upgrading.html#removed-tox-ini-keys)).

This PR removes the option.

## How this change was made

This change was made using search-and-replace across many repositories.


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>