### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: "trailing-whitespace"
 
   - repo: "https://github.com/asottile/pyupgrade"
-    rev: "v3.19.0"
+    rev: "v3.19.1"
     hooks:
       - id: "pyupgrade"
         name: "Enforce Python 3.9+ idioms"
@@ -37,7 +37,7 @@ repos:
       - id: "black"
 
   - repo: "https://github.com/pycqa/isort"
-    rev: "5.13.2"
+    rev: "6.0.0"
     hooks:
       - id: "isort"
 
@@ -46,9 +46,9 @@ repos:
     hooks:
       - id: "flake8"
         additional_dependencies:
-          - "flake8-bugbear==24.10.31"
+          - "flake8-bugbear==24.12.12"
 
-  - repo: "https://github.com/editorconfig-checker/editorconfig-checker.python"
-    rev: "3.0.3"
+  - repo: "https://github.com/editorconfig-checker/editorconfig-checker"
+    rev: "v3.2.0"
     hooks:
       - id: "editorconfig-checker"


### PR DESCRIPTION

This resolves pre-commit deprecation warnings about isort.
Also, switch to plain old editorconfig-checker.