### PR TITLE
Updates: PEP 621, copyrights, prep-release workflow

### DIFF
--- a/.github/workflows/prep-release.yaml
+++ b/.github/workflows/prep-release.yaml
@@ -1,0 +1,31 @@
+name: "✨ Prep release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The new version"
+        type: "string"
+        required: true
+
+jobs:
+  prep-release:
+    name: "Prep release v${{ inputs.version }}"
+
+    permissions:
+      contents: "write"
+      pull-requests: "write"
+
+    strategy:
+      matrix:
+        include:
+          - tox-label-create-changes: "prep-release"
+            branch-name: "release/$VERSION"
+            commit-title: "Update project metadata"
+            pr-base: "releases"
+            pr-title: "Release v$VERSION"
+
+    uses: "kurtmckee/github-workflows/.github/workflows/create-pr.yaml@ca26472ada33aa277527450aa46436f530e3d2c1" # v1.4
+    with:
+      config: "${{ toJSON(matrix) }}"
+      version: "${{ inputs.version }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,13 @@ name: "🧪 Test"
 
 on:
   pull_request:
+    types:
+      - "opened"
+      - "reopened"
+      - "synchronize"
+      # Release automation opens PRs as drafts without triggering CI;
+      # clicking "Ready for review" in the UI will trigger test runs.
+      - "ready_for_review"
   push:
     branches:
       - "main"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
           - "--py39-plus"
 
   - repo: "https://github.com/psf/black-pre-commit-mirror"
-    rev: "24.10.0"
+    rev: "25.1.0"
     hooks:
       - id: "black"
 
@@ -42,7 +42,7 @@ repos:
       - id: "isort"
 
   - repo: "https://github.com/pycqa/flake8"
-    rev: "7.1.1"
+    rev: "7.1.2"
     hooks:
       - id: "flake8"
         additional_dependencies:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,5 @@
 ..  This file is part of the pelican_precompress plugin.
-..  Copyright 2019-2024 Kurt McKee <contactme@kurtmckee.org>
+..  Copyright 2019-2025 Kurt McKee <contactme@kurtmckee.org>
 ..  Released under the MIT license.
 
 Changelog

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2024 Kurt McKee <contactme@kurtmckee.org>
+Copyright (c) 2019-2025 Kurt McKee <contactme@kurtmckee.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ..  This file is part of the pelican_precompress plugin.
-..  Copyright 2019-2024 Kurt McKee <contactme@kurtmckee.org>
+..  Copyright 2019-2025 Kurt McKee <contactme@kurtmckee.org>
 ..  Released under the MIT license.
 
 pelican_precompress

--- a/changelog.d/20250226_040638_kurtmckee_updates.rst
+++ b/changelog.d/20250226_040638_kurtmckee_updates.rst
@@ -1,0 +1,5 @@
+Development
+-----------
+
+*   Add a workflow to prep release PRs.
+*   Migrate to PEP 621 project metadata.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,36 @@
+[project]
+name = "pelican_precompress"
+version = "2.2.0"
+description = "Pre-compress your Pelican site using gzip, zopfli, and brotli!"
+authors = [
+    { name = "Kurt McKee", email = "contactme@kurtmckee.org" },
+]
+license = "MIT"
+readme = "README.rst"
+keywords = [
+    "pelican",
+    "plugin",
+    "gzip",
+    "brotli",
+    "zopfli",
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Framework :: Pelican :: Plugins",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+]
+requires-python = ">=3.9"
+dependencies = [
+    "pelican-granular-signals >=1.0.0,<2.0.0",
+]
+
+[project.urls]
+Source = "https://github.com/kurtmckee/pelican-precompress"
+Changelog = "https://github.com/kurtmckee/pelican-precompress/blob/main/CHANGELOG.rst"
+
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 
@@ -7,25 +38,9 @@ build-backend = "poetry.core.masonry.api"
 # ------
 
 [tool.poetry]
-name = "pelican_precompress"
-version = "2.2.0"
-description = "Pre-compress your Pelican site using gzip, zopfli, and brotli!"
-authors = ["Kurt McKee <contactme@kurtmckee.org>"]
-license = "MIT"
 packages = [
     { include = "pelican", from = "src" }
 ]
-readme = "README.rst"
-repository = "https://github.com/kurtmckee/pelican_precompress/"
-keywords = ["pelican", "plugin", "gzip", "brotli", "zopfli"]
-classifiers = [
-    "Framework :: Pelican :: Plugins",
-    "Development Status :: 5 - Production/Stable",
-]
-
-[tool.poetry.dependencies]
-python = ">=3.9"
-pelican-granular-signals = "^1.0.0"
 
 
 # coverage

--- a/src/pelican/plugins/precompress/__init__.py
+++ b/src/pelican/plugins/precompress/__init__.py
@@ -1,5 +1,5 @@
 # This file is part of the pelican-precompress plugin.
-# Copyright 2019-2024 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2019-2025 Kurt McKee <contactme@kurtmckee.org>
 # Released under the MIT license.
 
 from __future__ import annotations

--- a/tests/test_pelican_precompress.py
+++ b/tests/test_pelican_precompress.py
@@ -1,5 +1,5 @@
 # This file is part of the pelican-precompress plugin.
-# Copyright 2019-2024 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2019-2025 Kurt McKee <contactme@kurtmckee.org>
 # Released under the MIT license.
 
 import gzip

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,19 @@ commands =
     upadup
 
 
+[testenv:prep-release]
+description = Make the changes needed to create a new release PR
+skip_install = true
+deps =
+    poetry
+    scriv
+passenv =
+    VERSION
+commands =
+    poetry version "{env:VERSION}"
+    scriv collect
+
+
 [flake8]
 max-line-length = 88
 extend-ignore =


### PR DESCRIPTION
* Migrate to PEP 621 project metadata
* Update copyrights
* Run `pre-commit autoupdate; upadup`
* Add a prep-release-PR workflow