### PR TITLE
Support Python 3.14

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,15 +29,16 @@ There are three steps required to start using static compression:
 -----------------------------
 
 At minimum, you'll need to install the pelican_precompress plugin.
-It will automatically generate gzip files because gzip is built into the
-Python standard library.
+It will automatically generate gzip files on all versions of Python,
+and zstandard files on Python 3.14 and higher,
+because those compression algorithms are built into the Python standard library.
 
 However, if you want better compression you'll need to install additional packages.
 pelican_precompress exposes each compression algorithm by name as a package extra:
 
 *   ``brotli``
 *   ``zopfli``
-*   ``zstandard``
+*   ``zstandard`` (for Python 3.13 and lower)
 
 These can be selected as a comma-separated list during install:
 
@@ -138,11 +139,12 @@ You set them in your Pelican configuration file.
     If you set this to ``True`` when the brotli module isn't installed
     then nothing will happen.
 
-*   ``PRECOMPRESS_ZSTANDARD`` (bool, default is True if pyzstd is installed)
+*   ``PRECOMPRESS_ZSTANDARD`` (bool, default is True if zstandard is available)
 
-    If the pyzstd module is installed this will default to ``True``.
+    When running on Python 3.14 or higher with zstandard support compiled in,
+    or if the pyzstd module is installed, this will default to ``True``.
     You might set this to ``False`` during development.
-    If you set this to ``True`` when the pyzstd module isn't installed
+    If you set this to ``True`` when the zstandard compression isn't available
     then nothing will happen.
 
 *   ``PRECOMPRESS_ZOPFLI`` (bool, default is True if zopfli is installed)

--- a/changelog.d/20250521_172903_kurtmckee_py3_14.rst
+++ b/changelog.d/20250521_172903_kurtmckee_py3_14.rst
@@ -1,0 +1,12 @@
+Python support
+--------------
+
+*   Support Python 3.14.
+
+Changed
+-------
+
+*   zstandard support now uses ``compression.zstd`` on Python 3.14 and higher.
+
+    This means that zstandard is now enabled by default on Python 3.14 and higher.
+    ``pyzstd`` is still needed for Python 3.13 and lower.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 [project.optional-dependencies]
 brotli = ["brotli"]
 zopfli = ["zopfli"]
-zstandard = ["pyzstd"]
+zstandard = ["pyzstd; python_version<'3.14'"]
 
 [project.urls]
 Source = "https://github.com/kurtmckee/pelican-precompress"

--- a/src/pelican/plugins/precompress/__init__.py
+++ b/src/pelican/plugins/precompress/__init__.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import functools
-import gzip
 import logging
 import multiprocessing
 import pathlib
@@ -14,6 +13,8 @@ from collections.abc import Iterable
 
 import blinker
 import pelican.plugins.granular_signals
+
+from .compat import compression
 
 log = logging.getLogger(__name__)
 
@@ -31,13 +32,6 @@ except ModuleNotFoundError:
     log.debug("zopfli is not installed.")
     log.debug("Note: pelican_precompress only targets zopfli, not zopflipy.")
     zopfli = None
-
-# zstandard support is optional.
-try:
-    import pyzstd
-except ModuleNotFoundError:
-    log.debug("pyzstd is not installed.")
-    pyzstd = None
 
 
 DEFAULT_TEXT_EXTENSIONS: set[str] = {
@@ -77,7 +71,7 @@ def get_settings(instance) -> dict[str, bool | pathlib.Path | set[str]]:
         "PRECOMPRESS_GZIP": instance.settings.get("PRECOMPRESS_GZIP", True),
         "PRECOMPRESS_ZOPFLI": instance.settings.get("PRECOMPRESS_ZOPFLI", bool(zopfli)),
         "PRECOMPRESS_ZSTANDARD": instance.settings.get(
-            "PRECOMPRESS_ZSTANDARD", bool(pyzstd)
+            "PRECOMPRESS_ZSTANDARD", bool(compression.zstd)
         ),
         "PRECOMPRESS_OVERWRITE": instance.settings.get("PRECOMPRESS_OVERWRITE", False),
         "PRECOMPRESS_MIN_SIZE": instance.settings.get("PRECOMPRESS_MIN_SIZE", 20),
@@ -103,7 +97,7 @@ def get_settings(instance) -> dict[str, bool | pathlib.Path | set[str]]:
         settings["PRECOMPRESS_GZIP"] = False
 
     # If zstandard is enabled, it must be installed.
-    if settings["PRECOMPRESS_ZSTANDARD"] and not pyzstd:
+    if settings["PRECOMPRESS_ZSTANDARD"] and not compression.zstd:
         log.error("Disabling zstandard pre-compression because it is not installed.")
         settings["PRECOMPRESS_ZSTANDARD"] = False
 
@@ -248,7 +242,7 @@ def decompress_with_gzip(path: pathlib.Path) -> bytes | None:
     """Decompress a file using gzip decompression."""
 
     try:
-        return gzip.decompress(path.read_bytes())
+        return compression.gzip.decompress(path.read_bytes())
     except OSError:
         return None
 
@@ -257,7 +251,7 @@ def decompress_with_gzip(path: pathlib.Path) -> bytes | None:
 def compress_with_gzip(data: bytes) -> bytes:
     """Compress binary data using gzip compression."""
 
-    compressor = zlib.compressobj(level=9, wbits=16 + zlib.MAX_WBITS)
+    compressor = compression.zlib.compressobj(level=9, wbits=16 + zlib.MAX_WBITS)
     return compressor.compress(data) + compressor.flush()
 
 
@@ -272,8 +266,8 @@ def decompress_with_zstandard(path: pathlib.Path) -> bytes | None:
     """Decompress a file using zstandard decompression."""
 
     try:
-        return pyzstd.decompress(path.read_bytes())
-    except pyzstd.ZstdError:
+        return compression.zstd.decompress(path.read_bytes())
+    except compression.zstd.ZstdError:
         return None
 
 
@@ -281,7 +275,7 @@ def decompress_with_zstandard(path: pathlib.Path) -> bytes | None:
 def compress_with_zstandard(data: bytes) -> bytes:
     """Compress binary data using zstandard compression."""
 
-    return pyzstd.compress(data)
+    return compression.zstd.compress(data)
 
 
 def register():

--- a/src/pelican/plugins/precompress/compat.py
+++ b/src/pelican/plugins/precompress/compat.py
@@ -1,0 +1,32 @@
+# This file is part of the pelican-precompress plugin.
+# Copyright 2019-2025 Kurt McKee <contactme@kurtmckee.org>
+# Released under the MIT license.
+
+from __future__ import annotations
+
+import logging
+import types
+
+log = logging.getLogger(__name__)
+
+compression: types.SimpleNamespace | types.ModuleType
+
+try:
+    import compression.gzip
+    import compression.zlib
+    import compression.zstd
+except ModuleNotFoundError:
+    import gzip
+    import zlib
+
+    # zstandard support is optional.
+    try:
+        import pyzstd
+    except ModuleNotFoundError:
+        log.debug("pyzstd is not installed.")
+        pyzstd = None
+
+    compression = types.SimpleNamespace()
+    compression.gzip = gzip
+    compression.zlib = zlib
+    compression.zstd = pyzstd


### PR DESCRIPTION
Python support
--------------

*   Support Python 3.14.

Changed
-------

*   zstandard support now uses ``compression.zstd`` on Python 3.14 and higher.

    This means that zstandard is now enabled by default on Python 3.14 and higher.
    ``pyzstd`` is still needed for Python 3.13 and lower.
